### PR TITLE
Fix memory leaks, use RAII everywhere

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Configure and build
       run: |
-        meson setup builddir --buildtype release
+        meson setup builddir --buildtype release -Ddefault_library=static -Dcpp_link_args=-static
         meson compile -C builddir
 
     - name: Upload

--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,7 @@ sources = [
 
 vapoursynth_dep = dependency('vapoursynth').partial_dependency(compile_args : true, includes : true)
 
-boost_dep = dependency('boost', modules : ['filesystem', 'system'], static : true)
+boost_dep = dependency('boost', modules : ['filesystem'], static : true)
 
 opencl_dep = dependency('OpenCL', required : false)
 if not opencl_dep.found()


### PR DESCRIPTION
Replace array allocations with vectors and wrap VS structs in unique_ptrs so that nnedi3Free() only has to destroy the data struct. 

This removes some of the leaks shown in valgrind, the ones that remain at least don't *look* like they're caused by sneedif.

Please do test extensively before merging, in case this breaks anything.