### PR TITLE
add mutex around per thread data

### DIFF
--- a/SNEEDIF/shared.hpp
+++ b/SNEEDIF/shared.hpp
@@ -25,6 +25,7 @@
 #include <cstdlib>
 #include <locale>
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -66,6 +67,12 @@ public:
         }
 };
 
+struct PerThreadData {
+    compute::command_queue queue;
+    compute::kernel kernel;
+    compute::image2d src, dst, tmp;
+};
+
 struct NNEDI3Data {
         std::unique_ptr<VSNode, void(*)(VSNode *)> prop_node{nullptr, [](VSNode *){}};
         std::unique_ptr<VSNode, void(*)(VSNode *)> node{nullptr, [](VSNode *){}};
@@ -77,9 +84,8 @@ struct NNEDI3Data {
         compute::device device;
         compute::context context;
         compute::program program;
-        std::unordered_map<std::thread::id, compute::command_queue> queue;
-        std::unordered_map<std::thread::id, compute::kernel> kernel;
-        std::unordered_map<std::thread::id, compute::image2d> src, dst, tmp;
+        std::mutex per_thread_data_mutex;
+        std::unordered_map<std::thread::id, PerThreadData> per_thread_data;
         compute::buffer weights0, weights1Buffer;
         ClMemHolder weights1;
 };


### PR DESCRIPTION
feel free to see this just as issue plus proposed fix, and fix differently

problem repro
```python
from vstools import *

for i in range(1000):
    for f in core.std.BlankClip(format=vs.YUV420P8,length=core.num_threads*3).sneedif.NNEDI3(field=0).frames(close=True):
        pass
    print(f"pass {i}")
```
```
No entry point found in /usr/lib/vapoursynth/libbestsource.so
pass 0
pass 1
pass 2
pass 3
pass 4
pass 5
pass 6
pass 7
pass 8
terminate called after throwing an instance of 'std::out_of_range'
  what():  unordered_map::at
zsh: IOT instruction  python repro.py
```
